### PR TITLE
Topic add custom tags

### DIFF
--- a/app/src/allowed-html-tags/html-tags.module.js
+++ b/app/src/allowed-html-tags/html-tags.module.js
@@ -37,37 +37,37 @@ module.exports = [
    },
    {
       opening: 'h1',
-      openingRtf: '{\\pard',
+      openingRtf: '{\\pard\\fs64',
       closing: '/h1',
       closingRtf: '\\sb70\\par}'
    },
    {
       opening: 'h2',
-      openingRtf: '{\\pard',
+      openingRtf: '{\\pard\\fs48',
       closing: '/h2',
       closingRtf: '\\sb70\\par}'
    },
    {
       opening: 'h3',
-      openingRtf: '{\\pard',
+      openingRtf: '{\\pardc',
       closing: '/h3',
       closingRtf: '\\sb70\\par}'
    },
    {
       opening: 'h4',
-      openingRtf: '{\\pard',
+      openingRtf: '{\\pard\\fs32',
       closing: '/h4',
       closingRtf: '\\sb70\\par}'
    },
    {
       opening: 'h5',
-      openingRtf: '{\\pard',
+      openingRtf: '{\\pard22',
       closing: '/h5',
       closingRtf: '\\sb70\\par}'
    },
    {
       opening: 'h6',
-      openingRtf: '{\\pard',
+      openingRtf: '{\\pard23',
       closing: '/h6',
       closingRtf: '\\sb70\\par}'
    },

--- a/app/src/allowed-html-tags/html-tags.module.js
+++ b/app/src/allowed-html-tags/html-tags.module.js
@@ -37,13 +37,13 @@ module.exports = [
    },
    {
       opening: 'h1',
-      openingRtf: '{\\pard\\f0\\fs48',
+      openingRtf: '{\\pard\\f0\\fs36',
       closing: '/h1',
       closingRtf: '\\par}'
    },
    {
       opening: 'h2',
-      openingRtf: '{\\pard\\f0\\fs36',
+      openingRtf: '{\\pard\\f0\\fs28',
       closing: '/h2',
       closingRtf: '\\par}'
    },
@@ -55,19 +55,19 @@ module.exports = [
    },
    {
       opening: 'h4',
-      openingRtf: '{\\pard\\f0\\fs22',
+      openingRtf: '{\\pard',
       closing: '/h4',
       closingRtf: '\\par}'
    },
    {
       opening: 'h5',
-      openingRtf: '{\\pard\\f0\\fs18',
+      openingRtf: '{\\pard',
       closing: '/h5',
       closingRtf: '\\par}'
    },
    {
       opening: 'h6',
-      openingRtf: '{\\pard\\f0\\fs16',
+      openingRtf: '{\\pard',
       closing: '/h6',
       closingRtf: '\\par}'
    },

--- a/app/src/allowed-html-tags/html-tags.module.js
+++ b/app/src/allowed-html-tags/html-tags.module.js
@@ -37,39 +37,39 @@ module.exports = [
    },
    {
       opening: 'h1',
-      openingRtf: '{\\pard\\fs64',
+      openingRtf: '{\\pard\\f0\\fs48',
       closing: '/h1',
-      closingRtf: '\\sb70\\par}'
+      closingRtf: '\\par}'
    },
    {
       opening: 'h2',
-      openingRtf: '{\\pard\\fs48',
+      openingRtf: '{\\pard\\f0\\fs36',
       closing: '/h2',
-      closingRtf: '\\sb70\\par}'
+      closingRtf: '\\par}'
    },
    {
       opening: 'h3',
-      openingRtf: '{\\pardc',
+      openingRtf: '{\\pard\\f0\\fs24',
       closing: '/h3',
-      closingRtf: '\\sb70\\par}'
+      closingRtf: '\\par}'
    },
    {
       opening: 'h4',
-      openingRtf: '{\\pard\\fs32',
+      openingRtf: '{\\pard\\f0\\fs22',
       closing: '/h4',
-      closingRtf: '\\sb70\\par}'
+      closingRtf: '\\par}'
    },
    {
       opening: 'h5',
-      openingRtf: '{\\pard22',
+      openingRtf: '{\\pard\\f0\\fs18',
       closing: '/h5',
-      closingRtf: '\\sb70\\par}'
+      closingRtf: '\\par}'
    },
    {
       opening: 'h6',
-      openingRtf: '{\\pard23',
+      openingRtf: '{\\pard\\f0\\fs16',
       closing: '/h6',
-      closingRtf: '\\sb70\\par}'
+      closingRtf: '\\par}'
    },
    {
       opening: 'i',

--- a/app/src/allowed-html-tags/html-tags.module.js
+++ b/app/src/allowed-html-tags/html-tags.module.js
@@ -37,21 +37,21 @@ module.exports = [
    },
    {
       opening: 'h1',
-      openingRtf: '{\\pard\\f0\\fs36',
+      openingRtf: '{\\pard\\f0\\fs36',  // 18 point font
       closing: '/h1',
       closingRtf: '\\par}'
    },
    {
       opening: 'h2',
-      openingRtf: '{\\pard\\f0\\fs28',
+      openingRtf: '{\\pard\\f0\\fs28\\b', // 14 point font
       closing: '/h2',
-      closingRtf: '\\par}'
+      closingRtf: '\\b0\\par}'
    },
    {
       opening: 'h3',
-      openingRtf: '{\\pard\\f0\\fs24',
+      openingRtf: '{\\pard\\f0\\fs24\\b', // 12 point font
       closing: '/h3',
-      closingRtf: '\\par}'
+      closingRtf: '\\b0\\par}'
    },
    {
       opening: 'h4',

--- a/app/src/rtf/rtf.class.js
+++ b/app/src/rtf/rtf.class.js
@@ -26,7 +26,7 @@ class Rtf {
     return this.buildRtf();
   }
 
-// regex: starts with alpha char, followed by alpha or numeric, btn angle brackets, may include "/"
+// regex: starts with alpha char, followed by alpha or numeric, btwn angle brackets, may include "/"
   swapHtmlStrangerTags(html, dafaultTag) {
     return html.replace(/<(\/?[a-zA-Z_]+[a-zA-Z0-9_]*)( *[^>]*)?>/gi, (match, tagName, options) => {
       let newTag = !tagName.includes('/') ? `<${ dafaultTag }${ options ? options : '' }>` : `</${ dafaultTag }>`;

--- a/app/src/rtf/rtf.class.js
+++ b/app/src/rtf/rtf.class.js
@@ -7,7 +7,7 @@ const juice 		      = require('juice');
 const fs 				      = require('fs');
 
 class Rtf {
-  constructor() { 
+  constructor() {
     this.rtfHeaderOpening = "{\\rtf1\\ansi\\deff0{\\fonttbl {\\f0\\fnil\\fcharset0 Calibri;}{\\f1\\fnil\\fcharset2 Symbol;}}";
     this.rtfHeaderContent = '';
     this.rtfClosing = "}";
@@ -26,12 +26,14 @@ class Rtf {
     return this.buildRtf();
   }
 
+// regex: starts with alpha char, followed by alpha or numeric, btn angle brackets, may include "/"
   swapHtmlStrangerTags(html, dafaultTag) {
-    return html.replace(/<(\/?[a-z-]+)( *[^>]*)?>/gi, (match, tagName, options) => {
+    return html.replace(/<(\/?[a-zA-Z_]+[a-zA-Z0-9_]*)( *[^>]*)?>/gi, (match, tagName, options) => {
       let newTag = !tagName.includes('/') ? `<${ dafaultTag }${ options ? options : '' }>` : `</${ dafaultTag }>`;
       return AllowedHtmlTags.isKnowedTag(tagName) ? match : `${ newTag }`;
     });
   }
+
 
   buildRtf() {
     this.rtfHeaderContent += Style.getRtfColorTable();
@@ -78,7 +80,7 @@ class Rtf {
       if(tableChildren[tbodyIndex].children[i].type != 'text') {
         (tableChildren[tbodyIndex].children[i].children).forEach((child, index) => {
           if(child.type != 'text')
-            count++;          
+            count++;
         });
         break;
       }
@@ -108,7 +110,7 @@ class Rtf {
 
   addContentOfTagInRtfCode(contentOfTag) {
     contentOfTag = MyString.removeCharacterOfEscapeInAllString(contentOfTag, '\n\t');
-   
+
     if(contentOfTag != undefined && !MyString.hasOnlyWhiteSpace(contentOfTag))
       this.rtfContentReferences.push({ content: this.addSpaceAroundString(contentOfTag.trim()), tag: false });
   }
@@ -132,7 +134,7 @@ class Rtf {
 
   clearCacheContent() {
     this.rtfHeaderContent = '';
-    this.rtfContentReferences = [];    
+    this.rtfContentReferences = [];
   }
 
 }

--- a/app/src/rtf/rtf.class.js
+++ b/app/src/rtf/rtf.class.js
@@ -27,13 +27,12 @@ class Rtf {
   }
 
 // regex: starts with alpha char, followed by alpha or numeric, btwn angle brackets, may include "/"
-  swapHtmlStrangerTags(html, dafaultTag) {
+  swapHtmlStrangerTags(html, defaultTag) {
     return html.replace(/<(\/?[a-zA-Z_]+[a-zA-Z0-9_]*)( *[^>]*)?>/gi, (match, tagName, options) => {
-      let newTag = !tagName.includes('/') ? `<${ dafaultTag }${ options ? options : '' }>` : `</${ dafaultTag }>`;
+      let newTag = !tagName.includes('/') ? `<${ defaultTag }${ options ? options : '' }>` : `</${ defaultTag }>`;
       return AllowedHtmlTags.isKnowedTag(tagName) ? match : `${ newTag }`;
     });
   }
-
 
   buildRtf() {
     this.rtfHeaderContent += Style.getRtfColorTable();

--- a/app/src/style/style.class.js
+++ b/app/src/style/style.class.js
@@ -28,7 +28,7 @@ class Style {
 
     let fictitiousTagWithTruthStyle = "<span style='"+styleValue+"'></span>";
     let listOfRtfReferences = '';
-    
+
     AllowedStyleProperties.getAllowedTags().forEach(value => {
       if($(fictitiousTagWithTruthStyle).css(value.propertyName) != undefined) {
         switch(value.propertyName) {
@@ -41,7 +41,7 @@ class Style {
 
     if(listOfRtfReferences == '')
       return undefined;
-      
+
     return listOfRtfReferences;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
-  "name": "html-to-rtf",
-  "version": "1.3.2",
-  "author": {
-    "name": "Ozires R.S.O.F",
-    "email": "oziresrds@yahoo.com.br"
-  },
+  "name": "@textio/html-to-rtf",
+  "version": "1.3.3",
   "description": "Convert html to rtf format in the server",
   "readmeFilename": "README.md",
   "keywords": [
@@ -32,6 +28,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/oziresrds/html-to-rtf.git"
+    "url": "git://github.com/textioHQ/html-to-rtf.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,14 @@
   },
   "description": "Convert html to rtf format in the server",
   "readmeFilename": "README.md",
-  "keywords": ["html", "rtf", "convert", "server", "node", "javascript"],
+  "keywords": [
+    "html",
+    "rtf",
+    "convert",
+    "server",
+    "node",
+    "javascript"
+  ],
   "license": "MIT",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
### Summary of Changes 
This PR corrects a package bug that prevented html `heading` tags from being properly converted to their desired rich text format representation. It also supplies heading tags with a rich text format font size and removes the trailing space `\\sb70`. 

### Regex update: 
The prior regex --> `<(\/?[a-z-]+)( *[^>]*)?>` captured any number of alpha chars between angle brackets, separating the html tag text (and forward slash for closing tags) from the opening and closing brackets. Because numeric values were not being captured, heading tag text was not being fully separated from  their opening and closing tags, which resulted in the desired rich text formatting to appear after the html, instead of around it. 

The new regex specifically captures text within html tags that starts with an alpha, and is preceded by any number of alpha or numeric characters.

### Testing
The new package was tested using a job post returned from the `blocks-conversion-service` via the `/documentStateToHTML` endpoint. 

### Sample HTML
`<p>First line of this document's header</p><p>Second line of this document's header</p><h1>The Title H1</h1><p>This is a short paragraph between titles!</p><h2>A sub title - not as big but still important; H2</h2><p><b>Thi</b><span><b>s</b></span><span> is just </span><m>some</m> ordinary text</p><ul><li>Unordered 1</li><li>Unordered 2</li><li>Unordered 3</li></ul><ol><li>Ordered 1</li><li>Ordered 2</li><li>Ordered 3</li></ol><p>This is the end</p><p>An unstyled footer for this document</p><ul><li>An unordered list item in the footer</li></ul>`

To do:
- Finalize font sizes for RTF docs produced using this package. 
- Update the readme